### PR TITLE
feat: do not emit request code if the google api options is not defined

### DIFF
--- a/templates/ts/method.ejs
+++ b/templates/ts/method.ejs
@@ -7,15 +7,17 @@
     outputType
   } = method;
 
-  const http = helper.mapHTTPOptions(options.http);
+  const http = helper.mapHTTPOptions(options ? options.http : {});
   const request = helper.mapFieldTypeName(inputType, filename).type;
   const response = helper.mapFieldTypeName(outputType, filename).type;
 
 %>
+<% if(options) { %>
 export class <%= name %> implements APIRequest<<%= request %>, <%= response %>> {
-  _response?: <%=response%>
+  _response?: <%= response %>
   path = "<%= http.path %>";
   method: HTTPMethod = "<%= http.method %>";
   constructor(public parameter: <%= request %>) {
   }
 }
+<% } %>

--- a/templates/ts/service.ejs
+++ b/templates/ts/service.ejs
@@ -1,5 +1,7 @@
+<% if (service.methodList.some(method => method.options)) { %>
 export namespace <%= service.name %> {
   <% service.methodList.forEach( method => { _%>
   <%- include('method', { method, helper }) _%>
   <% }); %>
 }
+<% } %>


### PR DESCRIPTION
# Description

Please feel free to notify me if the description is not enough and you cannot get the point.

## Summary

- Do not emit request class if proto definitions do not implement the http custom options.

## Details

From the README, this plugin provides these two features:

> - Generate TypeScript definitions according to the spec.
> - Generate request class from the method definition if custom options are defined.

I don't know this plugin strictly expects the proto file to implement custom options, but if not, the plugin should emit something without any error when I pass the proto definition which does not implement the http custom options.

More details...

By the current implementation, it emits an error like this:

<details>
<summary>
Error message
</summary>

```
{ TypeError: ejs:33
    31|
    32| <% serviceList.forEach( service => { %>
 >> 33| <%- include('/ts/service', { service, helper, filename: name, config }) %>
    34| <% }); %>
    35|
    36| <% messageTypeList.forEach( message => { %>

.../protoc-gen-jsonpb-ts/templates/ts/service.ejs:3
    1| export namespace <%= service.name %> {
    2|   <% service.methodList.forEach( method => { _%>
 >> 3|   <%- include('method', { method, helper }) _%>
    4|   <% }); %>
    5| }

.../protoc-gen-jsonpb-ts/templates/ts/method.ejs:1
 >> 1| <%
    2|   const {
    3|     options,
    4|     name,

Cannot read property 'http' of undefined
   ...
--jsonpb-ts_out: protoc-gen-jsonpb-ts: Plugin failed with status code 2.
```
</details>

By the suggested implementation, it emits only interface without request class.
