### PR TITLE
Add support for json_name

### DIFF
--- a/src/export-map.ts
+++ b/src/export-map.ts
@@ -12,10 +12,17 @@ interface Definition {
   packageName: string;
 }
 
+interface JsonNameMapping {
+  messageName: string;
+  fieldName: string;
+  jsonName: string;
+}
+
 export class ExportMap {
   definitionMap: Record<string, Definition> = {};
   protoMap: Record<string, FileDescriptorProto> = {};
   fieldMap: Record<string, string[]> = {};
+  jsonNameMap: Record<string, JsonNameMapping[]> = {};
 
   public getDefinition(typeName: string): Definition {
     return this.definitionMap[typeName];
@@ -81,6 +88,9 @@ export class ExportMap {
     if (this.fieldMap[filename] === undefined) {
       this.fieldMap[filename] = [];
     }
+    if (this.jsonNameMap[filename] === undefined) {
+      this.jsonNameMap[filename] = [];
+    }
     this.definitionMap[name] = {
       typeName: name,
       filename,
@@ -88,6 +98,13 @@ export class ExportMap {
     };
     message.getFieldList().forEach(field => {
       this.fieldMap[filename].push(field.getTypeName().slice(1));
+      if (field.getJsonName() !== undefined) {
+        this.jsonNameMap[filename].push({
+          messageName: message.getName(),
+          fieldName: field.getName(),
+          jsonName: field.getJsonName()
+        });
+      }
     });
     message.getEnumTypeList().forEach(enumType => {
       this.readEnum(enumType, proto, name);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -11,7 +11,7 @@ export abstract class Helper {
 
   abstract mapImports(dependencies: string[], filename: string): DependencySchema[];
   abstract mapHTTPOptions(http: HTTPRule);
-  abstract mapFieldName(name: string): string;
+  abstract mapFieldName(name: string, filename: string, messageName: string): string;
   abstract mapFieldType(
     proto: FieldDescriptorProto.AsObject,
     filename: string

--- a/src/ts/helper.ts
+++ b/src/ts/helper.ts
@@ -42,8 +42,15 @@ export class TSHelper extends Helper {
     );
   }
 
-  mapFieldName(name: string): string {
-    return snakeToCamel(name);
+  mapFieldName(name: string, filename: string, messageName: string): string {
+    const mapping = this.map.jsonNameMap[filename].find(
+      m => m.messageName === messageName && m.fieldName === name
+    );
+    if (mapping) {
+      return mapping.jsonName;
+    } else {
+      return snakeToCamel(name);
+    }
   }
 
   mapFieldType(

--- a/templates/ts/field.ejs
+++ b/templates/ts/field.ejs
@@ -3,7 +3,7 @@
   const isRepeated = helper.isRepeated(field);
   const type = helper.mapFieldType(field, filename).type;
   const typeName = isRepeated ? type + "[]" : type;
-  const name = helper.mapFieldName(field.name);
+  const name = helper.mapFieldName(field.name, filename, messageName);
   const labeledName = isRequired ? name : name + "?"
 _%>
 <%= labeledName %>: <%- typeName %>;

--- a/templates/ts/message.ejs
+++ b/templates/ts/message.ejs
@@ -4,7 +4,7 @@ const hasNested = nestedTypeList.length > 0 || enumTypeList.length > 0
 _%>
 export interface <%= name %> {
 <% fieldList.forEach( field => { _%>
-  <%- include('field', { field, helper, filename, config }) %>
+  <%- include('field', { field, helper, filename, messageName: name, config }) %>
 <% }); %>
 }
 <% if (hasNested) { %>


### PR DESCRIPTION
Hi,

When integrating protoc-gen-jsonpb-ts into a project I'm working on I noticed it doesnt yet support the `json_name` field option ([see docs](https://developers.google.com/protocol-buffers/docs/proto3#json)), which allows to override the default snake-to-camel-case conversion.

This adds support by storing the `json_name` mappings during `ExportMap.addProto`, and reading from them again in `TSHelper.mapFieldName`.

Let me know if I can follow up with changes to get this to a place where you'd be happy merging this in!

--Joren