### PR TITLE
fix: enums are numbers, not strings

### DIFF
--- a/templates/ts/enum.ejs
+++ b/templates/ts/enum.ejs
@@ -12,6 +12,6 @@ export enum <%= name %> {
 <%_ } else { %>
 export type <%= name %> = 
   <%_ valueList.forEach( (value, index) => { _%>
-  "<%=value.name%>"<% if (!isLastIndex(index)) { %> | <% } %>
+  <%=value.number%><% if (!isLastIndex(index)) { %> | <% } %>
   <% }); _%>
 <% } %>

--- a/templates/ts/enum.ejs
+++ b/templates/ts/enum.ejs
@@ -6,7 +6,7 @@ _%>
 <%_ if (enumFormat === "enum") { %>
 export enum <%= name %> {
   <%_ valueList.forEach( (value, index) => { _%>
-  <%=value.name%> = "<%=value.name%>"<% if (!isLastIndex(index)) { %>, <% } %>
+  <%=value.name%> = <%=value.number%><% if (!isLastIndex(index)) { %>, <% } %>
   <% }); _%>
 }
 <%_ } else { %>


### PR DESCRIPTION
[Protobuf says](https://developers.google.com/protocol-buffers/docs/proto3#enum)

> Enumerator constants must be in the range of a 32-bit integer. 

It's the same for [proto2](https://developers.google.com/protocol-buffers/docs/proto).

With the [default configuration](https://github.com/sue71/protoc-gen-jsonpb-ts/blob/80800daa2c2ed3f49cf344dc7ba7711e1697a004/src/config.ts#L52), this [sample file](https://github.com/googleapis/googleapis/blob/dc65f39f33cb139b3a2244199a3e722a4d94b679/google/rpc/code.proto#L25-L186) is compiled incorrectly.

The [README](https://github.com/sue71/protoc-gen-jsonpb-ts/blob/80800daa2c2ed3f49cf344dc7ba7711e1697a004/README.md) says

> Generate TypeScript definitions according to the spec. 

Therefore, we should fix the behaviour.

This is a breaking change for clients that depend on the non-spec compliant behaviour.

### Current behaviour

On 80800da:

```
~/git/googleapis master
❯ git log --oneline -1
dc65f39f3 (HEAD -> master, origin/master, origin/HEAD) For Secret Manager v1 and v1beta1, noted Secret ID character limitations.

~/git/mercari/googleapis master*
❯ (cd ../protoc-gen-jsonpb-ts; git log --oneline -1)
80800da (HEAD -> master, origin/master, origin/HEAD) Merge pull request #36 from sue71/renovate/prettier-2.x

~/git/googleapis master
❯ protoc --version
libprotoc 3.7.1

~/git/googleapis master*
❯ node --version
v10.16.0

~/git/googleapis master
❯ test -d ./out && rm -rf ./out; mkdir ./out; protoc -I . --plugin=../protoc-gen-jsonpb-ts/bin/protoc-gen-jsonpb-ts --jsonpb-ts_out="ignorePackage=true:./out" google/rpc/code.proto; cat ./out/google/rpc/code_pb.ts
/* GENERATED FROM google/rpc/code.proto. DO NOT EDIT MANUALLY. */
/* tslint:disabled */
/* eslint-disable */

export enum Code {
  OK = "OK",
  CANCELLED = "CANCELLED",
  UNKNOWN = "UNKNOWN",
  INVALID_ARGUMENT = "INVALID_ARGUMENT",
  DEADLINE_EXCEEDED = "DEADLINE_EXCEEDED",
  NOT_FOUND = "NOT_FOUND",
  ALREADY_EXISTS = "ALREADY_EXISTS",
  PERMISSION_DENIED = "PERMISSION_DENIED",
  UNAUTHENTICATED = "UNAUTHENTICATED",
  RESOURCE_EXHAUSTED = "RESOURCE_EXHAUSTED",
  FAILED_PRECONDITION = "FAILED_PRECONDITION",
  ABORTED = "ABORTED",
  OUT_OF_RANGE = "OUT_OF_RANGE",
  UNIMPLEMENTED = "UNIMPLEMENTED",
  INTERNAL = "INTERNAL",
  UNAVAILABLE = "UNAVAILABLE",
  DATA_LOSS = "DATA_LOSS",
}

~/git/googleapis master*
❯ test -d ./out && rm -rf ./out; mkdir ./out; protoc -I . --plugin=../protoc-gen-jsonpb-ts/bin/protoc-gen-jsonpb-ts --jsonpb-ts_out="ignorePackage=true,enumFormat=stringLiteral:./out" google/rpc/code.proto; cat ./out/google/rpc/code_pb.ts

/* GENERATED FROM google/rpc/code.proto. DO NOT EDIT MANUALLY. */
/* tslint:disabled */
/* eslint-disable */

export type Code =
  | "OK"
  | "CANCELLED"
  | "UNKNOWN"
  | "INVALID_ARGUMENT"
  | "DEADLINE_EXCEEDED"
  | "NOT_FOUND"
  | "ALREADY_EXISTS"
  | "PERMISSION_DENIED"
  | "UNAUTHENTICATED"
  | "RESOURCE_EXHAUSTED"
  | "FAILED_PRECONDITION"
  | "ABORTED"
  | "OUT_OF_RANGE"
  | "UNIMPLEMENTED"
  | "INTERNAL"
  | "UNAVAILABLE"
  | "DATA_LOSS";

```

### Expected behaviour (fixed in this PR)

```
~/git//googleapis master
❯ git log --oneline -1
dc65f39f3 (HEAD -> master, origin/master, origin/HEAD) For Secret Manager v1 and v1beta1, noted Secret ID character limitations.

~/git//googleapis master*
❯ (cd ../protoc-gen-jsonpb-ts; git log --oneline -1)
ca3d056 (HEAD -> fix/enums-are-numbers, eqyiel/fix/enums-are-numbers) fix: also use number type when "stringLiteral" option is passed

~/git/googleapis master
❯ protoc --version
libprotoc 3.7.1

~/git/googleapis master*
❯ node --version
v10.16.0

~/git/googleapis master
❯ test -d ./out && rm -rf ./out; mkdir ./out; protoc -I . --plugin=../protoc-gen-jsonpb-ts/bin/protoc-gen-jsonpb-ts --jsonpb-ts_out="ignorePackage=true:./out" google/rpc/code.proto; cat ./out/google/rpc/code_pb.ts
/* GENERATED FROM google/rpc/code.proto. DO NOT EDIT MANUALLY. */
/* tslint:disabled */
/* eslint-disable */

export enum Code {
  OK = 0,
  CANCELLED = 1,
  UNKNOWN = 2,
  INVALID_ARGUMENT = 3,
  DEADLINE_EXCEEDED = 4,
  NOT_FOUND = 5,
  ALREADY_EXISTS = 6,
  PERMISSION_DENIED = 7,
  UNAUTHENTICATED = 16,
  RESOURCE_EXHAUSTED = 8,
  FAILED_PRECONDITION = 9,
  ABORTED = 10,
  OUT_OF_RANGE = 11,
  UNIMPLEMENTED = 12,
  INTERNAL = 13,
  UNAVAILABLE = 14,
  DATA_LOSS = 15,
}

~/git/googleapis master*
❯ test -d ./out && rm -rf ./out; mkdir ./out; protoc -I . --plugin=../protoc-gen-jsonpb-ts/bin/protoc-gen-jsonpb-ts --jsonpb-ts_out="ignorePackage=true,enumFormat=stringLiteral:./out" google/rpc/code.proto; cat ./out/google/rpc/code_pb.ts

/* GENERATED FROM google/rpc/code.proto. DO NOT EDIT MANUALLY. */
/* tslint:disabled */
/* eslint-disable */

export type Code =
  | 0
  | 1
  | 2
  | 3
  | 4
  | 5
  | 6
  | 7
  | 16
  | 8
  | 9
  | 10
  | 11
  | 12
  | 13
  | 14
  | 15;
```